### PR TITLE
change vllm gpu_memory_utilization from 0.7 to 0.6 to avoid OOM

### DIFF
--- a/examples/run_qwen2_5_vl_7b_geo.sh
+++ b/examples/run_qwen2_5_vl_7b_geo.sh
@@ -27,7 +27,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=4 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
     actor_rollout_ref.rollout.name=vllm \
-    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
     actor_rollout_ref.rollout.n=5 \
     actor_rollout_ref.rollout.enforce_eager=False \
     actor_rollout_ref.rollout.free_cache_engine=False \


### PR DESCRIPTION
Setting actor_rollout_ref.rollout.gpu_memory_utilization to 0.7 would cause OOM for a GPU node with 80G*8 VRAM. So decrease it from 0.7 to 0.6.