### PR TITLE
fix: math reward fn

### DIFF
--- a/verl/workers/reward/custom.py
+++ b/verl/workers/reward/custom.py
@@ -49,10 +49,11 @@ class CustomRewardManager:
             # decode
             sequences = torch.cat((valid_prompt_ids, valid_response_ids))
             sequences_str = self.tokenizer.decode(sequences, skip_special_tokens=True)
+            response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
 
             ground_truth = data_item.non_tensor_batch["answer"]
 
-            score = self.compute_score(sequences_str, ground_truth)
+            score = self.compute_score(response_str, ground_truth)
             reward_tensor[i, valid_response_length - 1] = score
 
             if already_print < self.num_examine:


### PR DESCRIPTION
Currently, the reward fn intends to give  +0.1 reward to encourage output answer in the format of `\boxed{}`.

However, in `CustomRewardManager` class, it uses `sequences = torch.cat((valid_prompt_ids, valid_response_ids))` as the input of `self.compute_score`. In this way,  var `seqences` includes the system prompt "Please reason step by step, and put your final answer within \boxed{}.". 

Note that the system prompt already includes `\boxed{}`. Thus the reward fn gives +0.1 even the model acutally output without \boxed{}. An example is below:

Fix this bug by passing the response without system prompt into `self.compute_score`

![image](https://github.com/user-attachments/assets/06b57e7d-e956-4006-840c-0bc6bd8440b9)