### PR TITLE
Added monkey patch for fused linear cross entropy

### DIFF
--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -34,11 +34,12 @@ def apply_monkey_patch_to_llama():
 
 
 def apply_monkey_patch_to_qwen2():
-    from transformers.models.qwen2.modeling_qwen2 import Qwen2FlashAttention2
+    from transformers.models.qwen2.modeling_qwen2 import Qwen2FlashAttention2, Qwen2ForCausalLM
 
-    from verl.models.transformers.qwen2 import qwen2_flash_attn_forward
+    from verl.models.transformers.qwen2 import qwen2_flash_attn_forward, qwen2_causal_lm_forward
 
     Qwen2FlashAttention2.forward = qwen2_flash_attn_forward
+    Qwen2ForCausalLM.forward = qwen2_causal_lm_forward
 
 
 _PATCH_NAME_TO_FUNC = {

--- a/verl/models/transformers/qwen2.py
+++ b/verl/models/transformers/qwen2.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
+from transformers import Qwen2ForCausalLM
 from transformers.cache_utils import Cache
 from transformers.modeling_flash_attention_utils import _flash_attention_forward
+from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb, repeat_kv
 from transformers.utils import logging
 
@@ -25,6 +27,7 @@ from verl.utils.ulysses import (
     gather_seq_scatter_heads,
     get_ulysses_sequence_parallel_world_size,
 )
+from verl.utils.fused_linear_cross_entropy import linear_cross_entropy
 
 
 logger = logging.get_logger(__name__)
@@ -145,3 +148,74 @@ def qwen2_flash_attn_forward(
         attn_weights = None
 
     return attn_output, attn_weights, past_key_value
+
+
+def qwen2_causal_lm_forward(
+    self: Qwen2ForCausalLM,
+    input_ids: torch.LongTensor = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[List[torch.FloatTensor]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    num_logits_to_keep: int = 0,
+    **loss_kwargs,
+):
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+    outputs = self.model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=return_dict,
+        cache_position=cache_position,
+    )
+
+    hidden_states = outputs[0]
+
+    # # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+    hidden_states = hidden_states[:, -num_logits_to_keep:, :]
+
+    logits = None
+    loss = None
+    if labels is not None:
+        # Note: to update this part of the code to deal with the gradient
+        # accumulation problem from https://unsloth.ai/blog/gradient
+        loss = linear_cross_entropy(
+            in_feat=hidden_states,
+            proj_weight=self.lm_head.weight,
+            targ=labels,
+            reduction="mean",
+            shift=True,
+            num_items_in_batch=loss_kwargs.get("num_items_in_batch", None),
+        )
+
+    else:
+        logits = self.lm_head(hidden_states)
+
+    if not return_dict:
+        output = (logits,) + outputs[1:]
+        return (loss,) + output if loss is not None else output
+
+    return CausalLMOutputWithPast(
+        loss=loss,
+        logits=logits,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+    )

--- a/verl/utils/fused_linear_cross_entropy.py
+++ b/verl/utils/fused_linear_cross_entropy.py
@@ -1,0 +1,231 @@
+from typing import Optional
+import torch
+import triton
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fused_cross_entropy_fwd_bwd_kernel(
+    output_loss_ptr,
+    output_logit_grad_ptr,
+    input_logit_ptr,
+    input_targ_ptr,
+    input_divisor_ptr,
+    output_loss_stride,
+    output_logit_grad_stride,
+    input_logit_stride,
+    input_targ_stride,
+    n_cols,
+    ignore_index,
+    BLOCK_SIZE: tl.constexpr,
+):
+    # Get pointers to current row for all inputs/outputs
+    row_idx = tl.program_id(0)
+    logit_grad_row_start_ptr = output_logit_grad_ptr + row_idx * output_logit_grad_stride
+    logit_row_start_ptr = input_logit_ptr + row_idx * input_logit_stride
+    targ_ptr = input_targ_ptr + row_idx * input_targ_stride
+    loss_ptr = output_loss_ptr + row_idx * output_loss_stride
+
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    logit_row_ptrs = logit_row_start_ptr + col_offsets
+    logit_grad_row_ptrs = logit_grad_row_start_ptr + col_offsets
+
+    # Load data into SRAM
+    logit_row_unnormalized = tl.load(
+        logit_row_ptrs, mask=col_offsets < n_cols, other=float("-Inf")
+    )
+    targ = tl.load(targ_ptr)
+    divisor = tl.load(input_divisor_ptr)
+
+    # Normalize logits and compute some useful intermediate values
+    logit_row = logit_row_unnormalized - tl.max(
+        logit_row_unnormalized, axis=0
+    )  # Subtract max value for numerical stability
+    exp_logit_row = tl.exp(logit_row)
+    sum_exp_logit_row = tl.sum(exp_logit_row, axis=0)
+
+    # Compute loss
+    log_sum_exp_logit_row = tl.log(sum_exp_logit_row)
+    logit_gt_logit = tl.sum(tl.where(targ == col_offsets, logit_row, 0.0))
+    loss = log_sum_exp_logit_row - logit_gt_logit
+    loss = loss / divisor
+    loss = tl.where(targ == ignore_index, 0.0, loss)
+    tl.store(loss_ptr, loss)
+
+    # Compute gradients
+    targ_one_hot = tl.where(targ == col_offsets, 1.0, 0.0)
+    grad = (exp_logit_row / sum_exp_logit_row - targ_one_hot)
+    grad = grad / divisor
+    grad = tl.where(targ == ignore_index, 0.0, grad)
+    tl.store(logit_grad_row_ptrs, grad, mask=col_offsets < n_cols)
+
+
+class FusedCrossEntropyLossFunction(torch.autograd.Function):
+    # NOTE: We put the linear projection in the same autograd Function as the loss computation
+    # because we overwrite the logits with their gradients inplace to avoid allocating more
+    # memory for the gradients, and so we keep the logits completely contained within this
+    # Functionto avoid possible side-effects if they were exposed.
+
+    @staticmethod
+    def forward(
+        ctx,
+        in_feat: torch.Tensor,
+        proj_weight: torch.Tensor,
+        targ: torch.Tensor,
+        # n_loop_iters: int,
+        ignore_index: int,
+        reduction: str,
+        num_items_in_batch: Optional[int],
+    ):
+        n_tokens = in_feat.shape[0]
+        n_classes = proj_weight.shape[0]
+
+        assert in_feat.ndim == 2, in_feat.ndim
+        assert proj_weight.ndim == 2, proj_weight.ndim
+        assert targ.ndim == 1, targ.shape
+        assert in_feat.shape[0] == targ.shape[0], f"Number of tokens in in_feat and targ is not equal: {(in_feat.shape, targ.shape) = }"
+        assert reduction in ("mean", "sum"), reduction
+
+        NUM_WARPS = 16
+
+        BLOCK_SIZE = triton.next_power_of_2(n_classes)
+
+        loss = torch.empty(n_tokens, dtype=in_feat.dtype, device=in_feat.device)
+        dtype = torch.get_autocast_gpu_dtype() if torch.is_autocast_enabled() else in_feat.dtype
+
+        if proj_weight.requires_grad:
+            grad_proj_weight = torch.zeros_like(proj_weight, dtype=dtype)
+        else:
+            grad_proj_weight = None
+
+        if in_feat.requires_grad:
+            grad_in_feat = torch.zeros_like(in_feat)
+        else:
+            grad_in_feat = None
+
+        if reduction == "mean":
+            if num_items_in_batch is None:
+                divisor = (targ != ignore_index).sum().to(dtype)
+            else:
+                divisor = torch.ones(1, dtype=dtype, device=in_feat.device) * num_items_in_batch
+        else:
+            divisor = torch.ones(1, dtype=dtype, device=in_feat.device)
+
+        # divisor = (targ != ignore_index).sum().to(dtype) if reduction == "mean" else torch.ones(1, dtype=dtype, device=in_feat.device)
+
+        # Divide the input into chunks of size num_tokens // n_loop_iters, then compute the loss for each of these groups
+        proj_weight_cast = proj_weight.to(dtype)
+
+        # Hard code to 1024 tokens per chunk, this probably isn't optimal.
+        loop_chunk_size = 1024
+        logits_chunk_cast = torch.zeros((loop_chunk_size, n_classes), dtype=dtype, device=in_feat.device)
+        for i, in_feat_chunk in enumerate(torch.split(in_feat, loop_chunk_size)):
+            token_start_idx = i * loop_chunk_size
+            token_end_idx = (i + 1) * loop_chunk_size
+
+            in_feat_chunk = in_feat_chunk.to(dtype)
+            n_tokens_chunk = in_feat_chunk.shape[0]
+
+            # Size of final chunk might be smaller than loop_chunk_size
+            logits_chunk_cast = logits_chunk_cast[:n_tokens_chunk]
+
+            # Compute logits
+            torch.matmul(in_feat_chunk, proj_weight_cast.T, out=logits_chunk_cast)
+            logits_chunk = logits_chunk_cast.float()
+
+            # Compute loss
+            loss_chunk = loss[token_start_idx:token_end_idx]
+            targ_chunk = targ[token_start_idx:token_end_idx]
+
+            grad_logits_chunk = logits_chunk  # NOTE: we override the logits with their gradients
+            fused_cross_entropy_fwd_bwd_kernel[(n_tokens_chunk,)](
+                loss_chunk,
+                grad_logits_chunk,
+                logits_chunk,
+                targ_chunk,
+                divisor,
+                loss_chunk.stride(0),
+                grad_logits_chunk.stride(0),
+                logits_chunk.stride(0),
+                targ_chunk.stride(0),
+                n_classes,
+                ignore_index,
+                num_warps=NUM_WARPS,
+                BLOCK_SIZE=BLOCK_SIZE,
+            )
+
+            grad_logits_chunk = grad_logits_chunk.to(dtype)
+
+            if in_feat.requires_grad:
+                grad_in_feat[token_start_idx:token_end_idx] = grad_logits_chunk @ proj_weight_cast
+
+            if proj_weight.requires_grad:
+                torch.addmm(
+                    grad_proj_weight,
+                    grad_logits_chunk.T,
+                    in_feat_chunk,
+                    out=grad_proj_weight,
+                )
+
+        # NOTE: if reduction == "mean" we already divide by an appropriate normalization factor in the kernel so we can always sum here
+        loss = loss.sum()
+
+        # Save data for backward
+        ctx.in_feat_requires_grad = in_feat.requires_grad
+        ctx.proj_weight_requires_grad = proj_weight.requires_grad
+
+        if proj_weight.requires_grad and in_feat.requires_grad:
+            ctx.save_for_backward(grad_in_feat, grad_proj_weight)
+        elif proj_weight.requires_grad and not in_feat.requires_grad:
+            ctx.save_for_backward(grad_proj_weight)
+        elif not proj_weight.requires_grad and in_feat.requires_grad:
+            ctx.save_for_backward(grad_in_feat)
+
+        return loss
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        if ctx.in_feat_requires_grad and ctx.proj_weight_requires_grad:
+            grad_in_feat, grad_proj_weight = ctx.saved_tensors
+        elif not ctx.in_feat_requires_grad and ctx.proj_weight_requires_grad:
+            grad_proj_weight, = ctx.saved_tensors
+        elif ctx.in_feat_requires_grad and not ctx.proj_weight_requires_grad:
+            grad_in_feat, = ctx.saved_tensors
+
+        assert grad_output.shape == tuple(), grad_output.shape
+        grad_in_feat *= grad_output
+        grad_proj_weight *= grad_output
+
+        return grad_in_feat, grad_proj_weight, None, None, None, None
+
+
+def linear_cross_entropy(
+    in_feat: torch.Tensor,
+    proj_weight: torch.Tensor,
+    targ: torch.Tensor,
+    ignore_index: int = -100,
+    reduction: str = "mean",
+    shift: bool = False,
+    num_items_in_batch: Optional[int] = None,
+    **kwargs,
+) -> torch.Tensor:
+    hidden_size = in_feat.shape[-1]
+
+    if shift:
+        in_feat = in_feat[..., :-1, :].contiguous()
+        targ = targ[..., 1:].contiguous()
+
+    keep_pos = [targ != ignore_index]
+    in_feat = in_feat[keep_pos]
+    targ = targ[keep_pos]
+
+    return FusedCrossEntropyLossFunction.apply(
+        in_feat.view(-1, hidden_size),
+        proj_weight,
+        targ.view(-1),
+        ignore_index,
+        reduction,
+        num_items_in_batch,
+    )


### PR DESCRIPTION
This PR uses the chunking technique from cross cut entropy https://arxiv.org/abs/2411.09009 to optimize the memory cost incurred by cross entropy resulting from a long sequence and a large vocabulary.
And sequence lengths tends to get long in RL.

When testing apple's implementation of fused linear cross entropy https://github.com/apple/ml-cross-entropy, I found that activation values of logits tends to diverge from standard.

The implementation I've attached in this PR is a slightly slower and much more naive implementation using the same ideas to optimize the runtime memory.