### PR TITLE
Fix: save processor for VLMs

### DIFF
--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -21,7 +21,7 @@ import torch
 import torch.distributed
 from filelock import FileLock
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from transformers import PreTrainedTokenizer
+from transformers import PreTrainedTokenizer, ProcessorMixin
 
 
 class BaseCheckpointManager:
@@ -45,6 +45,7 @@ class BaseCheckpointManager:
         optimizer: torch.optim.Optimizer,
         lr_scheduler: torch.optim.lr_scheduler.LRScheduler,
         tokenizer: PreTrainedTokenizer,
+        processor: ProcessorMixin
     ):
         self.previous_global_step = None
         self.previous_save_local_path = None
@@ -53,6 +54,7 @@ class BaseCheckpointManager:
         self.optimizer = optimizer
         self.lr_scheduler = lr_scheduler
         self.tokenizer = tokenizer
+        self.processor = processor
 
         assert isinstance(self.model, FSDP)
         self.rank = torch.distributed.get_rank()

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -37,7 +37,7 @@ from transformers.modeling_utils import no_init_weights
 from verl import DataProto
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, register
-from verl.utils import get_tokenizer
+from verl.utils import get_tokenizer, get_processor
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.fsdp_utils import (
@@ -138,6 +138,7 @@ class FSDPWorker(Worker):
         padding_free: bool = False,
     ) -> None:
         self.tokenizer = get_tokenizer(model_config.tokenizer_path, trust_remote_code=model_config.trust_remote_code)
+        self.processor = get_processor(model_config.tokenizer_path)
         self.model_config = AutoConfig.from_pretrained(
             model_config.model_path,
             trust_remote_code=model_config.trust_remote_code,
@@ -325,6 +326,7 @@ class FSDPWorker(Worker):
                 optimizer=self.optimizer,
                 lr_scheduler=self.lr_scheduler,
                 tokenizer=self.tokenizer,
+                processor=self.processor
             )
 
         torch.cuda.empty_cache()


### PR DESCRIPTION
The previous saving logic only saves tokenizers, which misses "preprocessor_config.json" in the saved checkpoints.

The incomplete dump will raise an error when loading the processor:
```
OSError: debug_save does not appear to have a file named preprocessor_config.json. Checkout 'https://huggingface.co/debug_save/tree/main' for available files.
```