### PR TITLE
[env] fix memory leak & enable vLLM v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV NODE_OPTIONS=""
 # Define installation arguments
 ARG APT_SOURCE=https://mirrors.tuna.tsinghua.edu.cn/ubuntu/
 ARG PIP_INDEX=https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
+ARG VLLM_COMMIT=227578480d71fc94ef46ca77fb69496412158d68
 
 # Set apt source
 RUN cp /etc/apt/sources.list /etc/apt/sources.list.bak && \
@@ -36,8 +37,13 @@ RUN pip config set global.index-url "${PIP_INDEX}" && \
     pip config set global.extra-index-url "${PIP_INDEX}" && \
     python -m pip install --upgrade pip
 
-# Install torch-2.5.1 + vllm-0.7.3
-RUN pip install --no-cache-dir vllm==0.7.3 torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 tensordict torchdata \
+# Install vllm-0.7.4-nightly
+RUN pip install vllm --pre --extra-index-url "https://wheels.vllm.ai/${VLLM_COMMIT}" && \
+    git clone -b verl_v1 https://github.com/hiyouga/vllm.git && \
+    cp -r vllm/vllm/ /usr/local/lib/python3.10/dist-packages/
+
+# Install torch-2.5.1
+RUN pip install --no-cache-dir torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 tensordict torchdata \
     transformers>=4.49.0 accelerate datasets peft hf_transfer \
     ray codetiming hydra-core pandas pyarrow>=15.0.0 pylatexenc qwen-vl-utils wandb liger-kernel \
 

--- a/examples/run_qwen2_5_7b_math.sh
+++ b/examples/run_qwen2_5_7b_math.sh
@@ -1,6 +1,7 @@
 set -x
 
 export VLLM_ATTENTION_BACKEND=XFORMERS
+export VLLM_USE_V1=0
 
 MODEL_PATH=Qwen/Qwen2.5-7B-Instruct  # replace it with your local file path
 

--- a/examples/run_qwen2_5_7b_math_swanlab.sh
+++ b/examples/run_qwen2_5_7b_math_swanlab.sh
@@ -1,6 +1,7 @@
 set -x
 
 export VLLM_ATTENTION_BACKEND=XFORMERS
+export VLLM_USE_V1=0
 
 MODEL_PATH=Qwen/Qwen2.5-7B-Instruct  # replace it with your local file path
 

--- a/examples/run_qwen2_5_vl_3b_clevr.sh
+++ b/examples/run_qwen2_5_vl_3b_clevr.sh
@@ -1,6 +1,7 @@
 set -x
 
 export VLLM_ATTENTION_BACKEND=XFORMERS
+export VLLM_USE_V1=0
 
 MODEL_PATH=Qwen/Qwen2.5-VL-3B-Instruct  # replace it with your local file path
 

--- a/examples/run_qwen2_5_vl_3b_geo.sh
+++ b/examples/run_qwen2_5_vl_3b_geo.sh
@@ -1,6 +1,7 @@
 set -x
 
 export VLLM_ATTENTION_BACKEND=XFORMERS
+export VLLM_USE_V1=0
 
 MODEL_PATH=Qwen/Qwen2.5-VL-3B-Instruct  # replace it with your local file path
 

--- a/examples/run_qwen2_5_vl_7b_geo.sh
+++ b/examples/run_qwen2_5_vl_7b_geo.sh
@@ -1,6 +1,7 @@
 set -x
 
 export VLLM_ATTENTION_BACKEND=XFORMERS
+export VLLM_USE_V1=0
 
 MODEL_PATH=Qwen/Qwen2.5-VL-7B-Instruct  # replace it with your local file path
 

--- a/examples/run_qwen2_5_vl_7b_geo_swanlab.sh
+++ b/examples/run_qwen2_5_vl_7b_geo_swanlab.sh
@@ -1,6 +1,7 @@
 set -x
 
 export VLLM_ATTENTION_BACKEND=XFORMERS
+export VLLM_USE_V1=0
 
 MODEL_PATH=Qwen/Qwen2.5-VL-7B-Instruct  # replace it with your local file path
 


### PR DESCRIPTION
Fixes: #50 https://github.com/volcengine/verl/issues/429

Use the docker image to avoid OOM or execute

```bash
export VLLM_COMMIT=227578480d71fc94ef46ca77fb69496412158d68
sudo pip install vllm --pre --extra-index-url https://wheels.vllm.ai/${VLLM_COMMIT}
git clone -b verl_v1 https://github.com/hiyouga/vllm.git
sudo cp -r vllm/vllm/ /usr/local/lib/python3.10/dist-packages/
```