### PR TITLE
Fix: data split from local dir

### DIFF
--- a/verl/utils/dataset.py
+++ b/verl/utils/dataset.py
@@ -105,9 +105,9 @@ class RLHFDataset(Dataset):
             data_split = "train"
 
         if os.path.isdir(data_path):
-            self.dataset = load_dataset("parquet", data_dir=data_path, split="train")
+            self.dataset = load_dataset("parquet", data_dir=data_path, split=data_split)
         elif os.path.isfile(data_path):
-            self.dataset = load_dataset("parquet", data_files=data_path, split="train")
+            self.dataset = load_dataset("parquet", data_files=data_path, split=data_split)
         else:  # remote dataset
             self.dataset = load_dataset(data_path, split=data_split)
 


### PR DESCRIPTION
The val/test splits are not loaded correctly when using a local dataset directory, which has caused some confusion in my experiments.