### PR TITLE
feat: swanlab add `easyr1` and `verl` config

### DIFF
--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -59,11 +59,10 @@ class Tracking:
             swanlab.init(
                 project=project_name,
                 experiment_name=experiment_name,
-                config={"UPPERFRAMEWORK": "EasyR1", "FRAMEWORK": "veRL"},
+                config={"UPPERFRAMEWORK": "EasyR1", "FRAMEWORK": "veRL", **config},
                 logdir=SWANLAB_LOG_DIR,
                 mode=SWANLAB_MODE,
             )
-            swanlab.config.update(config)
             self.logger["swanlab"] = swanlab
 
         if "console" in default_backend:

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -59,10 +59,11 @@ class Tracking:
             swanlab.init(
                 project=project_name,
                 experiment_name=experiment_name,
-                config=config,
+                config={"UPPERFRAMEWORK": "EasyR1", "FRAMEWORK": "veRL"},
                 logdir=SWANLAB_LOG_DIR,
                 mode=SWANLAB_MODE,
             )
+            swanlab.config.update(config)
             self.logger["swanlab"] = swanlab
 
         if "console" in default_backend:


### PR DESCRIPTION
Add the identifiers for `easyr1` and `verl` in the swanlab config table, so more developers can see that this training comes from these two frameworks.