### PR TITLE
Update requirements.txt for multinode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pillow
 pyarrow>=15.0.0
 pylatexenc
 qwen-vl-utils
-ray
+ray[default]
 tensordict
 torchdata
 transformers>=4.49.0


### PR DESCRIPTION
we need to install ray[default], to enable dashboard for multinode training, which is aligned with the verl requirements.txt. 
https://github.com/volcengine/verl/blob/main/requirements.txt