### PR TITLE
Supports loading format prompt from a file

### DIFF
--- a/examples/format_prompts/demo.txt
+++ b/examples/format_prompts/demo.txt
@@ -1,0 +1,2 @@
+You FIRST think about the reasoning process as an internal monologue and then provide the final answer.
+The reasoning process MUST BE enclosed within <think> </think> tags. The final answer MUST BE put in \boxed{}.

--- a/examples/format_prompts/demo.txt
+++ b/examples/format_prompts/demo.txt
@@ -1,2 +1,0 @@
-You FIRST think about the reasoning process as an internal monologue and then provide the final answer.
-The reasoning process MUST BE enclosed within <think> </think> tags. The final answer MUST BE put in \boxed{}.

--- a/verl/trainer/config.py
+++ b/verl/trainer/config.py
@@ -43,11 +43,18 @@ class DataConfig:
     rollout_batch_size: int = 512
     val_batch_size: int = -1
     format_prompt: Optional[str] = None
+    format_prompt_path: Optional[str] = None
     shuffle: bool = True
     seed: int = 1
     max_pixels: int = 4194304
     min_pixels: int = 262144
 
+    def post_init(self):
+        if self.format_prompt is None and self.format_prompt_path is not None:
+            if os.path.exists(self.format_prompt_path):
+                self.format_prompt_path = os.path.abspath(self.format_prompt_path)
+                with open(self.format_prompt_path, "r", encoding="utf-8") as f:
+                    self.format_prompt = f.read()
 
 @dataclass
 class AlgorithmConfig:

--- a/verl/trainer/config.py
+++ b/verl/trainer/config.py
@@ -56,6 +56,7 @@ class DataConfig:
                 with open(self.format_prompt_path, "r", encoding="utf-8") as f:
                     self.format_prompt = f.read()
 
+
 @dataclass
 class AlgorithmConfig:
     gamma: float = 1.0


### PR DESCRIPTION
When `format_prompt` is directly defined in a shell script and contains lengthy content or special characters, decoding issues may occur. This PR introduces a simple capability to read `format_prompt` from a specified file path when the variable is empty, avoiding potential parsing errors.