### PR TITLE
[perf] pass raw image data between workers

### DIFF
--- a/verl/trainer/ray_trainer.py
+++ b/verl/trainer/ray_trainer.py
@@ -295,6 +295,10 @@ class RayPPOTrainer:
                 )
 
             test_gen_batch.meta_info = self.config.worker.rollout.val_override_config
+            test_gen_batch.meta_info.update({
+                "min_pixels": self.config.data.min_pixels,
+                "max_pixels": self.config.data.max_pixels,
+            })
             test_gen_batch, pad_size = pad_dataproto_to_divisor(test_gen_batch, self.actor_rollout_wg.world_size)
             test_output_gen_batch = self.actor_rollout_wg.generate_sequences(test_gen_batch)
             test_output_gen_batch = unpad_dataproto(test_output_gen_batch, pad_size=pad_size)
@@ -488,6 +492,10 @@ class RayPPOTrainer:
                         batch_keys=["input_ids", "attention_mask", "position_ids"],
                         non_tensor_batch_keys=["raw_prompt_ids", "multi_modal_data"],
                     )
+                    gen_batch.meta_info.update({
+                        "min_pixels": self.config.data.min_pixels,
+                        "max_pixels": self.config.data.max_pixels,
+                    })
                 else:
                     gen_batch = batch.pop(
                         batch_keys=["input_ids", "attention_mask", "position_ids"],

--- a/verl/trainer/ray_trainer.py
+++ b/verl/trainer/ray_trainer.py
@@ -528,7 +528,6 @@ class RayPPOTrainer:
                     # repeat to align with repeated responses in rollout
                     batch = batch.repeat(repeat_times=self.config.worker.rollout.n, interleave=True)
                     batch = batch.union(gen_batch_output)
-                    batch.non_tensor_batch.pop("multi_modal_data", None)
 
                     # balance the number of valid tokens on each dp rank.
                     # Note that this breaks the order of data inside the batch.

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -21,6 +21,7 @@ import numpy as np
 import psutil
 import torch
 import torch.distributed as dist
+from copy import deepcopy
 from accelerate import init_empty_weights
 from codetiming import Timer
 from torch.distributed.device_mesh import init_device_mesh
@@ -50,6 +51,7 @@ from ..utils.fsdp_utils import (
     offload_fsdp_model,
     offload_fsdp_optimizer,
 )
+from ..utils.dataset import process_image
 from ..utils.model_utils import print_gpu_memory_usage, print_model_size
 from ..utils.tokenizer import get_processor, get_tokenizer
 from ..utils.torch_dtypes import PrecisionType
@@ -424,9 +426,27 @@ class FSDPWorker(Worker):
         if self._use_optimizer_offload:  # avoid OOM in resuming
             offload_fsdp_optimizer(self.optimizer)
 
+    def preprocess_multi_modal_data(self, data: DataProto):
+        # inplace load & process image data
+        min_pixels = data.meta_info["min_pixels"]
+        max_pixels = data.meta_info["max_pixels"]
+        multi_modal_data_copy = deepcopy(data.non_tensor_batch["multi_modal_data"])
+        images = [multi_modal_data['image'] for multi_modal_data in multi_modal_data_copy]
+        for i, per_query_images in enumerate(images):
+            for j, image in enumerate(per_query_images):
+                images[i][j] = process_image(image, min_pixels=min_pixels, max_pixels=max_pixels)
+        multi_modal_inputs = np.array([
+            dict(self.processor.image_processor(images=per_query_images), videos=None)
+            for per_query_images in images
+        ], dtype=object)
+        data.non_tensor_batch["multi_modal_inputs"] = multi_modal_inputs
+
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def update_actor(self, data: DataProto):
         assert self._is_actor
+        if "multi_modal_data" not in data.non_tensor_batch:
+            self.preprocess_multi_modal_data(data)
+
         data = data.to(torch.cuda.current_device())
 
         if self._use_param_offload:
@@ -499,7 +519,30 @@ class FSDPWorker(Worker):
                 offload_fsdp_optimizer(optimizer=self.optimizer)
 
             prompts = self.rollout_sharding_manager.preprocess_data(prompts)
+
+            # load image data
+            if "multi_modal_data" in prompts.non_tensor_batch:
+                cached_multi_modal_data = deepcopy(prompts.non_tensor_batch["multi_modal_data"])
+                min_pixels = prompts.meta_info['min_pixels']
+                max_pixels = prompts.meta_info['max_pixels']
+                processed_images = []
+                for i, multi_modal_data in enumerate(prompts.non_tensor_batch["multi_modal_data"]):
+                    for j, image in enumerate(multi_modal_data["image"]):
+                        multi_modal_data['image'][j] = process_image(image, min_pixels=min_pixels, max_pixels=max_pixels)
+                    processed_images.append(multi_modal_data)
+                prompts.non_tensor_batch["multi_modal_data"] = processed_images
+
             output = self.rollout.generate_sequences(prompts=prompts)
+
+            if "multi_modal_data" in prompts.non_tensor_batch:
+                sampling_n = prompts.meta_info.get("n", self.config.rollout.n)
+                # restore multi_modal_data
+                output.non_tensor_batch["multi_modal_data"] = cached_multi_modal_data
+                if sampling_n > 1:
+                    output.non_tensor_batch["multi_modal_data"] = np.repeat(
+                        output.non_tensor_batch["multi_modal_data"], repeats=sampling_n, axis=0,
+                    )
+
             output = self.rollout_sharding_manager.postprocess_data(output)
 
         output = output.to("cpu")
@@ -508,6 +551,9 @@ class FSDPWorker(Worker):
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_log_probs(self, data: DataProto):
         assert self._is_actor
+        if "multi_modal_data" not in data.non_tensor_batch:
+            self.preprocess_multi_modal_data(data)
+
         data = data.to(torch.cuda.current_device())
         if self._use_param_offload:
             load_fsdp_model(self.fsdp_module)
@@ -537,6 +583,9 @@ class FSDPWorker(Worker):
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_ref_log_probs(self, data: DataProto):
         assert self._is_ref
+        if "multi_modal_data" not in data.non_tensor_batch:
+            self.preprocess_multi_modal_data(data)
+
         data = data.to(torch.cuda.current_device())
         if self._use_param_offload:
             load_fsdp_model(self.fsdp_module)
@@ -562,6 +611,9 @@ class FSDPWorker(Worker):
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_values(self, data: DataProto):
         assert self._is_critic
+        if "multi_modal_data" not in data.non_tensor_batch:
+            self.preprocess_multi_modal_data(data)
+
         data = data.to(torch.cuda.current_device())
         if self._use_param_offload:
             load_fsdp_model(self.fsdp_module)
@@ -580,6 +632,9 @@ class FSDPWorker(Worker):
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def update_critic(self, data: DataProto):
+        if "multi_modal_data" not in data.non_tensor_batch:
+            self.preprocess_multi_modal_data(data)
+
         data = data.to(torch.cuda.current_device())
         if self._use_param_offload:
             load_fsdp_model(self.fsdp_module)

--- a/verl/workers/rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout_spmd.py
@@ -198,4 +198,8 @@ class vLLMRollout(BaseRollout):
         if self.rank == 0:
             print("[Rollout] Finish generating sequences.")
 
-        return DataProto(batch=batch, non_tensor_batch=non_tensor_batch)
+        return DataProto(
+            batch=batch,
+            non_tensor_batch=non_tensor_batch,
+            meta_info=prompts.meta_info.copy(),
+        )


### PR DESCRIPTION
Instead of transmitting the preprocessed `pixel_values` between the master and worker nodes, we transmit the raw image data to reduce communication bandwidth requirements.