### PR TITLE
[feat] support ray.timeline

### DIFF
--- a/verl/trainer/config.py
+++ b/verl/trainer/config.py
@@ -141,6 +141,8 @@ class TrainerConfig:
     """save checkpoint path, if not specified, use `checkpoints/project_name/experiment_name`"""
     load_checkpoint_path: Optional[str] = None
     """load checkpoint path"""
+    ray_timeline: Optional[str] = None
+    """file to save ray timeline. set to None to disable"""
     find_last_checkpoint: bool = True
     """automatically find the last checkpoint in the save checkpoint path to resume training"""
 

--- a/verl/trainer/main.py
+++ b/verl/trainer/main.py
@@ -119,7 +119,8 @@ def main():
             }
         }
         ray.init(runtime_env=runtime_env)
-
+        if ppo_config.trainer.ray_timeline is not None:
+            ray.timeline(filename=ppo_config.trainer.ray_timeline)
     runner = Runner.remote()
     ray.get(runner.run.remote(ppo_config))
 

--- a/verl/trainer/main.py
+++ b/verl/trainer/main.py
@@ -121,6 +121,7 @@ def main():
         ray.init(runtime_env=runtime_env)
         if ppo_config.trainer.ray_timeline is not None:
             ray.timeline(filename=ppo_config.trainer.ray_timeline)
+            
     runner = Runner.remote()
     ray.get(runner.run.remote(ppo_config))
 


### PR DESCRIPTION
To generate a Ray timeline for performance analysis, pass the following argument when launching training: --trainer.ray_timeline <file_name>.json. You can visualize it in https://ui.perfetto.dev/