### PR TITLE
[model] fix: stuck issue with mixed text-image data

### DIFF
--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -176,7 +176,7 @@ def _get_input_embeds(
         video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
         inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
 
-    if model.training and pixel_values is None and pixel_values_videos is None:
+    if pixel_values is None and pixel_values_videos is None:
         pixel_values = torch.zeros((16, 1176), dtype=inputs_embeds.dtype, device=inputs_embeds.device)
         image_grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.long, device=inputs_embeds.device)
         image_embeds = model.visual(pixel_values, grid_thw=image_grid_thw)


### PR DESCRIPTION
Same as https://github.com/volcengine/verl/pull/3670, we should revert this part of change in https://github.com/hiyouga/EasyR1/commit/35e693a6544870372a1f1fbdae4bb54422e707d2, otherwise it will cause stuck again.

https://github.com/volcengine/verl/pull/3315#issuecomment-3315362541

It should be pretty safe and optional to do without `model.training` checks even the model is in inference mode, as the value of `inputs_embeds` won't get modified anyway.