### PR TITLE
[model] fix: qwen3vl training stuck with mixed text-image data

### DIFF
--- a/verl/models/transformers/qwen3_vl.py
+++ b/verl/models/transformers/qwen3_vl.py
@@ -208,8 +208,10 @@ def _get_input_embeds(
         patch_dim = config.in_channels * config.temporal_patch_size * config.patch_size**2
         pixel_values = torch.zeros((16, patch_dim), dtype=inputs_embeds.dtype, device=inputs_embeds.device)
         image_grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.long, device=inputs_embeds.device)
-        image_embeds, _ = model.visual(pixel_values, grid_thw=image_grid_thw)
+        image_embeds, dummy_deepstack_image_embeds = model.visual(pixel_values, grid_thw=image_grid_thw)
         inputs_embeds += 0.0 * image_embeds.mean()
+        for emb in dummy_deepstack_image_embeds or []:
+            inputs_embeds += 0.0 * emb.mean()
 
     if attention_mask is not None:
         attention_mask = attention_mask.to(inputs_embeds.device)


### PR DESCRIPTION
Refer to https://github.com/volcengine/verl/pull/3734

We should also do something similar to image_embeds for dummy_deepstack_image_embeds to maintain gradient flow