### PR TITLE
Add warmup style: cosine.

### DIFF
--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -214,9 +214,9 @@ def get_cosine_schedule_with_warmup(
     init_lr_ratio: Optional[float] = None,
 ):
     """
-    Create a schedule with a learning rate that decreases following the values of the cosine function between the
-    initial lr set in the optimizer to 0, after a warmup period during which it increases linearly between 0 and the
-    initial lr set in the optimizer.
+    Creates a learning rate schedule that linearly increases the learning rate ratio from `init_lr_ratio`
+    to 1.0 over the first `num_warmup_steps`, then applies a cosine decay from 1.0 down to `min_lr_ratio`
+    over the remaining training steps.
     Args:
         optimizer (:class:`~torch.optim.Optimizer`):
             The optimizer for which to schedule the learning rate.

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -208,10 +208,10 @@ def get_cosine_schedule_with_warmup(
     optimizer: torch.optim.Optimizer,
     num_warmup_steps: int,
     num_training_steps: int,
-    min_lr_ratio: float = 0.0,
+    min_lr_ratio: Optional[float] = 0.0,
     num_cycles: float = 0.5,
     last_epoch: int = -1,
-    init_lr_ratio: float = None,
+    init_lr_ratio: Optional[float] = None,
 ):
     """
     Create a schedule with a learning rate that decreases following the values of the cosine function between the

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -16,6 +16,7 @@
 Contain small torch utilities
 """
 
+import math
 from typing import List, Literal, Optional, Tuple, Union
 
 import torch
@@ -199,6 +200,56 @@ def get_constant_schedule_with_warmup(
             return min(1.0, float(current_step) / float(max(1, num_warmup_steps)))
 
         return 1.0
+
+    return LambdaLR(optimizer, lr_lambda, last_epoch)
+
+
+def get_cosine_schedule_with_warmup(
+    optimizer: torch.optim.Optimizer,
+    num_warmup_steps: int,
+    num_training_steps: int,
+    min_lr_ratio: float = 0.0,
+    num_cycles: float = 0.5,
+    last_epoch: int = -1,
+    init_lr_ratio: float = None,
+):
+    """
+    Create a schedule with a learning rate that decreases following the values of the cosine function between the
+    initial lr set in the optimizer to 0, after a warmup period during which it increases linearly between 0 and the
+    initial lr set in the optimizer.
+    Args:
+        optimizer (:class:`~torch.optim.Optimizer`):
+            The optimizer for which to schedule the learning rate.
+        num_warmup_steps (:obj:`int`):
+            The number of steps for the warmup phase.
+        num_training_steps (:obj:`int`):
+            The total number of training steps.
+        min_lr_ratio (:obj:`float`, `optional`, defaults to 0.0):
+            The minimum lr ratio w.r.t the maximum.
+        num_cycles (:obj:`float`, `optional`, defaults to 0.5):
+            The number of waves in the cosine schedule (the defaults is to just decrease from the max value to 0
+            following a half-cosine).
+        last_epoch (:obj:`int`, `optional`, defaults to -1):
+            The index of the last epoch when resuming training.
+        init_lr_ratio (:obj:`float`, `optional`, defaults to None):
+            The initial lr ratio w.r.t the maximum.
+    Return:
+        :obj:`torch.optim.lr_scheduler.LambdaLR` with the appropriate schedule.
+    """
+    min_lr_ratio = 0.0 if min_lr_ratio is None else min_lr_ratio
+    assert min_lr_ratio >= 0 and min_lr_ratio <= 1.0
+    coef = (1 - min_lr_ratio) * 0.5
+    intercept = (1 + min_lr_ratio) * 0.5
+
+    init_lr_ratio = 0.0 if init_lr_ratio is None else init_lr_ratio
+    assert init_lr_ratio >= 0 and init_lr_ratio <= 1.0
+
+    def lr_lambda(current_step):
+        if current_step < num_warmup_steps:
+            return init_lr_ratio + (1.0 - init_lr_ratio) * (float(current_step) / float(max(1, num_warmup_steps)))
+        progress = float(current_step - num_warmup_steps) / float(max(1, num_training_steps - num_warmup_steps))
+        x = math.cos(math.pi * float(num_cycles) * 2.0 * progress)
+        return max(min_lr_ratio, x * coef + intercept)
 
     return LambdaLR(optimizer, lr_lambda, last_epoch)
 

--- a/verl/workers/actor/config.py
+++ b/verl/workers/actor/config.py
@@ -50,6 +50,7 @@ class OptimConfig:
     lr_warmup_steps: Optional[int] = None
     min_lr_ratio: Optional[float] = None
     warmup_style: str = "constant"
+    num_cycles: float = 0.5
     # below are auto keys
     training_steps: int = field(default=-1, init=False)
 

--- a/verl/workers/actor/config.py
+++ b/verl/workers/actor/config.py
@@ -49,8 +49,7 @@ class OptimConfig:
     lr_warmup_ratio: float = 0.0
     lr_warmup_steps: Optional[int] = None
     min_lr_ratio: Optional[float] = None
-    warmup_style: str = "constant"
-    num_cycles: float = 0.5
+    lr_scheduler_type: str = "constant"
     # below are auto keys
     training_steps: int = field(default=-1, init=False)
 

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -311,14 +311,13 @@ class FSDPWorker(Worker):
             else:
                 num_warmup_steps = int(optim_config.lr_warmup_ratio * optim_config.training_steps)
 
-
             if optim_config.warmup_style == "constant":
                 self.lr_scheduler = get_constant_schedule_with_warmup(
                     optimizer=self.optimizer, num_warmup_steps=num_warmup_steps
                 )
             elif optim_config.warmup_style == "cosine":
                 total_steps = optim_config.training_steps
-                min_lr_ratio = optim_config.min_lr_ratio if optim_config.min_lr_ratio is not None else 0.0
+                min_lr_ratio = optim_config.min_lr_ratio
                 num_cycles = optim_config.num_cycles
                 self.lr_scheduler = get_cosine_schedule_with_warmup(
                     optimizer=self.optimizer,

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -54,7 +54,7 @@ from ..utils.fsdp_utils import (
 from ..utils.model_utils import print_gpu_memory_usage, print_model_size
 from ..utils.tokenizer import get_processor, get_tokenizer
 from ..utils.torch_dtypes import PrecisionType
-from ..utils.torch_functional import AnyPrecisionAdamW, get_constant_schedule_with_warmup
+from ..utils.torch_functional import AnyPrecisionAdamW, get_constant_schedule_with_warmup, get_cosine_schedule_with_warmup
 from .config import ActorConfig, CriticConfig, FSDPConfig, ModelConfig, OptimConfig, WorkerConfig
 from .rollout import vLLMRollout
 from .sharding_manager import FSDPVLLMShardingManager
@@ -311,9 +311,24 @@ class FSDPWorker(Worker):
             else:
                 num_warmup_steps = int(optim_config.lr_warmup_ratio * optim_config.training_steps)
 
-            self.lr_scheduler = get_constant_schedule_with_warmup(
-                optimizer=self.optimizer, num_warmup_steps=num_warmup_steps
-            )
+
+            if optim_config.warmup_style == "constant":
+                self.lr_scheduler = get_constant_schedule_with_warmup(
+                    optimizer=self.optimizer, num_warmup_steps=num_warmup_steps
+                )
+            elif optim_config.warmup_style == "cosine":
+                total_steps = optim_config.training_steps
+                min_lr_ratio = optim_config.min_lr_ratio if optim_config.min_lr_ratio is not None else 0.0
+                num_cycles = optim_config.num_cycles
+                self.lr_scheduler = get_cosine_schedule_with_warmup(
+                    optimizer=self.optimizer,
+                    num_warmup_steps=num_warmup_steps,
+                    num_training_steps=total_steps,
+                    min_lr_ratio=min_lr_ratio,
+                    num_cycles=num_cycles,
+                )
+            else:
+                raise NotImplementedError(f"Warmup style {optim_config.warmup_style} is not supported")
             print_gpu_memory_usage("After optimizer init")
             if self._use_param_offload:
                 offload_fsdp_model(self.fsdp_module)

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -311,14 +311,14 @@ class FSDPWorker(Worker):
             else:
                 num_warmup_steps = int(optim_config.lr_warmup_ratio * optim_config.training_steps)
 
-            if optim_config.warmup_style == "constant":
+            if optim_config.lr_scheduler_type == "constant":
                 self.lr_scheduler = get_constant_schedule_with_warmup(
                     optimizer=self.optimizer, num_warmup_steps=num_warmup_steps
                 )
-            elif optim_config.warmup_style == "cosine":
+            elif optim_config.lr_scheduler_type == "cosine":
                 total_steps = optim_config.training_steps
                 min_lr_ratio = optim_config.min_lr_ratio
-                num_cycles = optim_config.num_cycles
+                num_cycles = 0.5
                 self.lr_scheduler = get_cosine_schedule_with_warmup(
                     optimizer=self.optimizer,
                     num_warmup_steps=num_warmup_steps,
@@ -327,7 +327,7 @@ class FSDPWorker(Worker):
                     num_cycles=num_cycles,
                 )
             else:
-                raise NotImplementedError(f"Warmup style {optim_config.warmup_style} is not supported")
+                raise NotImplementedError(f"LR scheduler type {optim_config.lr_scheduler_type} is not supported")
             print_gpu_memory_usage("After optimizer init")
             if self._use_param_offload:
                 offload_fsdp_model(self.fsdp_module)


### PR DESCRIPTION
This PR introduces a new warmup style for learning rate scheduling: cosine warmup. Users can now specify `warmup_style: "cosine"` in the optimizer configuration.

Example script

```bash
#!/bin/bash

set -x

MODEL_PATH=Qwen/Qwen2.5-VL-3B-Instruct  # replace it with your local file path

python3 -m verl.trainer.main \
    config=examples/config.yaml \
    data.train_files=hiyouga/geometry3k@train \
    data.val_files=hiyouga/geometry3k@test \
    worker.actor.model.model_path=${MODEL_PATH} \
    worker.actor.optim.warmup_style=cosine \
    worker.actor.optim.training_steps=60 \
    trainer.experiment_name=qwen2_5_vl_3b_geo_grpo \
    trainer.n_gpus_per_node=4
```

update:

```bash
#!/bin/bash

set -x

MODEL_PATH=Qwen/Qwen2.5-VL-3B-Instruct  # replace it with your local file path

python3 -m verl.trainer.main \
    config=examples/config.yaml \
    data.train_files=hiyouga/geometry3k@train \
    data.val_files=hiyouga/geometry3k@test \
    worker.actor.model.model_path=${MODEL_PATH} \
    worker.actor.optim.lr_scheduler_type=cosine \
    worker.actor.optim.training_steps=60 \
    trainer.experiment_name=qwen2_5_vl_3b_geo_grpo \
    trainer.n_gpus_per_node=4
```