### PR TITLE
[algo] fix: avoid FSDP _is_root assertion when collecting LoRA weights

### DIFF
--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -120,7 +120,8 @@ class FSDPVLLMShardingManager(BaseShardingManager):
                     lora_weights[key] = lora_weight.full_tensor().detach().cpu()
                 else:
                     lora_weights[key] = lora_weight.detach().cpu()
-
+            
+            submodule._is_root = False
             if self.use_param_offload:
                 offload_fsdp_submodule(submodule)
 

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -120,7 +120,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
                     lora_weights[key] = lora_weight.full_tensor().detach().cpu()
                 else:
                     lora_weights[key] = lora_weight.detach().cpu()
-            
+
             submodule._is_root = False
             if self.use_param_offload:
                 offload_fsdp_submodule(submodule)


### PR DESCRIPTION
fix #649 

When `worker.actor.offload.offload_params=false`, we need to reset non-root FSDP modules in `_collect_lora_weights` (set `submodule._is_root = False`) to avoid the `Non-root FSDP instance's _is_root` assertion.