### PR TITLE
[deps] Allow transformers <5.0.0 for Qwen3-VL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ qwen-vl-utils
 ray[default]
 tensordict
 torchdata
-transformers>=4.54.0,<=4.57.0
+transformers>=4.54.0,<5.0.0
 vllm>=0.8.0
 wandb

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -120,7 +120,8 @@ class FSDPVLLMShardingManager(BaseShardingManager):
                     lora_weights[key] = lora_weight.full_tensor().detach().cpu()
                 else:
                     lora_weights[key] = lora_weight.detach().cpu()
-
+            
+            submodule._is_root = False
             if self.use_param_offload:
                 offload_fsdp_submodule(submodule)
 

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -120,7 +120,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
                     lora_weights[key] = lora_weight.full_tensor().detach().cpu()
                 else:
                     lora_weights[key] = lora_weight.detach().cpu()
-            
+
             submodule._is_root = False
             if self.use_param_offload:
                 offload_fsdp_submodule(submodule)


### PR DESCRIPTION
This PR is for #580.

When installing with `pip install -e .`, the current constraint `transformers<=4.57.0` does not support Qwen3-VL.

In addition, `transformers==4.57.0` has been yanked from PyPI, which may cause installation issues depending on the resolver.

This PR relaxes the constraint to `transformers<5.0.0`, allowing newer versions of transformers that support Qwen3-VL.