### PR TITLE
[worker] fix vLLM multimodal encoder_cache GPU memory leak

### DIFF
--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -207,12 +207,58 @@ class FSDPVLLMShardingManager(BaseShardingManager):
         print_gpu_memory_usage("After vllm offload in sharding manager")
 
         self.module.train()
+        # Drain vLLM's multimodal encoder cache before empty_cache so the freed image-embedding
+        # tensors are actually released (see _drain_vllm_encoder_cache for details).
+        self._drain_vllm_encoder_cache()
         torch.cuda.empty_cache()  # add empty cache after each compute
 
         # restore random states
         if self.device_mesh is not None:
             self.gen_random_states = torch.cuda.get_rng_state()
             torch.cuda.set_rng_state(self.torch_random_states)
+
+    def _drain_vllm_encoder_cache(self):
+        """Release vLLM's per-mm-hash GPU encoder cache between rollout steps.
+
+        For multimodal models, vLLM's V1 ``GpuModelRunner`` keeps an ``encoder_cache``
+        (``dict[mm_hash -> GPU tensor]`` of image/video encoder outputs). Entries are only evicted
+        by the scheduler's ``EncoderCacheManager`` under capacity pressure (it frees the oldest
+        entries only when a new request needs slots). In the colocated HybridEngine setup each
+        training step runs a single bounded ``generate`` call and then sleeps, so that pressure
+        never builds: finished-request entries are never reclaimed and the cache grows by roughly
+        one entry per image per step, leaking GPU memory across steps until an OOM in the actor
+        update. ``sleep(level=1)`` only offloads model weights, not this cache, and
+        ``torch.cuda.empty_cache()`` cannot reclaim it because the entries are still referenced.
+
+        Generation has fully completed by the time we offload (no unfinished requests), so it is
+        safe to drop the runner's cached tensors and reset the scheduler's cache-manager accounting
+        to its empty state. Best-effort and guarded: any vLLM-internal layout change degrades to a
+        no-op rather than breaking training.
+        """
+        try:
+            runner = self.inference_engine.llm_engine.model_executor.driver_worker.worker.model_runner
+            encoder_cache = getattr(runner, "encoder_cache", None)
+            if isinstance(encoder_cache, dict):
+                encoder_cache.clear()
+        except Exception:
+            pass
+
+        # Reset the scheduler-side EncoderCacheManager so the freed slots are reclaimed. The
+        # scheduler lives on the in-process EngineCore for the external_launcher (SPMD) backend.
+        try:
+            engine_core = self.inference_engine.llm_engine.engine_core
+            engine_core = getattr(engine_core, "engine_core", engine_core)  # unwrap in-process client
+            scheduler = getattr(engine_core, "scheduler", None)
+            manager = getattr(scheduler, "encoder_cache_manager", None)
+            if manager is not None and not scheduler.has_unfinished_requests():
+                manager.num_free_slots = manager.cache_size
+                manager.num_freeable_slots = manager.cache_size
+                manager.cached.clear()
+                if hasattr(manager, "freeable"):
+                    manager.freeable.clear()
+                manager.freed.clear()
+        except Exception:
+            pass
 
     def preprocess_data(self, data: DataProto) -> DataProto:
         """All gather across tp group to make each rank has identical input."""


### PR DESCRIPTION
### Problem

When training multimodal models (e.g. Qwen3-VL) with the colocated HybridEngine, GPU memory grows roughly linearly across training steps and eventually OOMs in the actor update (`update_actor` → `loss.backward()`). The leak is **image-only** (text-only runs are stable) and **resets on restart**, so resuming from a checkpoint runs for a bounded number of steps and then OOMs again.

### Root cause

vLLM's V1 `GpuModelRunner` keeps an `encoder_cache` (`dict[mm_hash -> GPU tensor]` of image/video encoder outputs). Entries are only evicted by the scheduler's `EncoderCacheManager` **under capacity pressure** — it frees the oldest freeable entries only when a new request needs slots.

In the colocated HybridEngine setup, each training step runs a single bounded `generate()` call and then sleeps, so that pressure never builds: each step's batch fits within the cache budget, the "need more slots" eviction path never fires, and finished-request entries are never reclaimed. The cache therefore grows by ~one entry per image per step (~0.25 GB/step for Qwen3‑VL on geometry3k) until CUDA OOM.

Two details make it stick:
- `sleep(level=1)` offloads only model **weights** (via `CuMemAllocator` with `offload_tags=("weights",)`), not this cache.
- `torch.cuda.empty_cache()` cannot reclaim it because the entries are still referenced by the dict.

Because vLLM runs in-process (SPMD / `external_launcher`) and shares the process CUDA allocator with training, the growth shows up as `torch.cuda.memory_allocated()`.

### Fix

Drain the encoder cache in `FSDPVLLMShardingManager.offload_vllm()` right after `sleep()`. Generation has fully completed by then (no unfinished requests), so it is safe to clear the runner's cached tensors and reset the scheduler-side `EncoderCacheManager` slot accounting to its empty state. The reset is best-effort and fully guarded (`try/except`, attribute checks, `has_unfinished_requests()`), so any vLLM-internal layout change degrades to a no-op rather than breaking training.

### Verification

Qwen3-VL-8B + geometry3k, colocated HybridEngine:
- `encoder_cache` stays at **0 entries per step** (was growing ~32/step).
- Post-rollout GPU usage goes **flat** instead of climbing ~0.25 GB/step; the OOM no longer occurs.
- **Step-1 reward/accuracy is bit-identical** to before the change (the drain runs after generation and does not touch the compute path); later steps differ only by normal RL run-to-run noise.

Relates to the memory-leak reports in #444 (and similar: #469, #398).
