### PR TITLE
[checkpoint] preserve generation config during model merge

### DIFF
--- a/.github/requirements-test.txt
+++ b/.github/requirements-test.txt
@@ -1,5 +1,6 @@
 codetiming
 datasets
+peft
 pillow
 pytest
 qwen-vl-utils

--- a/.github/requirements-test.txt
+++ b/.github/requirements-test.txt
@@ -1,6 +1,5 @@
 codetiming
 datasets
-peft
 pillow
 pytest
 qwen-vl-utils

--- a/scripts/model_merger.py
+++ b/scripts/model_merger.py
@@ -18,6 +18,7 @@ import json
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
 
 import numpy as np
 import torch
@@ -28,6 +29,7 @@ from transformers import (
     AutoModelForCausalLM,
     AutoModelForImageTextToText,
     AutoModelForTokenClassification,
+    GenerationConfig,
     PretrainedConfig,
     PreTrainedModel,
 )
@@ -44,11 +46,25 @@ def merge_by_placement(tensors: list[torch.Tensor], placement: Placement):
         raise ValueError(f"Unsupported placement: {placement}")
 
 
+def save_pretrained_with_generation_config(
+    model: PreTrainedModel,
+    hf_path: str,
+    generation_config: Optional[GenerationConfig],
+    **kwargs,
+) -> None:
+    """Save a model without replacing the checkpoint's generation configuration."""
+    if generation_config is not None:
+        model.generation_config = generation_config
+
+    model.save_pretrained(hf_path, **kwargs)
+
+
 def merge_lora_into_base_and_save(
     local_dir: str,
     state_dict: dict[str, torch.Tensor],
     hf_path: str,
     auto_class: type[PreTrainedModel],
+    generation_config: Optional[GenerationConfig],
 ) -> bool:
     """Merge LoRA weights into the base model before saving a dense HF checkpoint for vLLM."""
     adapter_cfg = os.path.join(local_dir, "lora_adapter", "adapter_config.json")
@@ -80,7 +96,7 @@ def merge_lora_into_base_and_save(
     print("Merging LoRA weights into base model...")
     merged = peft_model.merge_and_unload()
     print(f"Saving merged model to {hf_path}...")
-    merged.save_pretrained(hf_path, safe_serialization=True)
+    save_pretrained_with_generation_config(merged, hf_path, generation_config, safe_serialization=True)
     return True
 
 
@@ -96,7 +112,12 @@ def upload_model_to_huggingface(local_path: str, remote_path: str):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--local_dir", required=True, type=str, help="The path for your saved model")
-    parser.add_argument("--hf_upload_path", default=False, type=str, help="The path of the huggingface repo to upload")
+    parser.add_argument(
+        "--hf_upload_path",
+        default=False,
+        type=str,
+        help="The path of the huggingface repo to upload",
+    )
     args = parser.parse_args()
     local_dir: str = os.path.abspath(args.local_dir)
 
@@ -204,6 +225,8 @@ if __name__ == "__main__":
     print("Merge completed.")
     hf_path = os.path.join(local_dir, "huggingface")
     config: PretrainedConfig = AutoConfig.from_pretrained(hf_path)
+    generation_config_path = os.path.join(hf_path, "generation_config.json")
+    generation_config = GenerationConfig.from_pretrained(hf_path) if os.path.isfile(generation_config_path) else None
     architectures: list[str] = getattr(config, "architectures", ["Unknown"])
 
     if "ForTokenClassification" in architectures[0]:
@@ -215,7 +238,7 @@ if __name__ == "__main__":
     else:
         raise NotImplementedError(f"Unknown architecture {architectures}.")
 
-    if merge_lora_into_base_and_save(local_dir, state_dict, hf_path, AutoClass):
+    if merge_lora_into_base_and_save(local_dir, state_dict, hf_path, AutoClass, generation_config):
         del state_dict
     else:
         with torch.device("meta"):
@@ -225,7 +248,7 @@ if __name__ == "__main__":
         model.to_empty(device="cpu")
 
         print(f"Saving model to {hf_path}...")
-        model.save_pretrained(hf_path, state_dict=state_dict)
+        save_pretrained_with_generation_config(model, hf_path, generation_config, state_dict=state_dict)
         del state_dict, model
 
     if args.hf_upload_path:

--- a/scripts/model_merger.py
+++ b/scripts/model_merger.py
@@ -22,7 +22,6 @@ from typing import Optional
 
 import numpy as np
 import torch
-from peft import LoraConfig, get_peft_model
 from torch.distributed._tensor import DTensor, Placement, Shard
 from transformers import (
     AutoConfig,
@@ -67,6 +66,8 @@ def merge_lora_into_base_and_save(
     generation_config: Optional[GenerationConfig],
 ) -> bool:
     """Merge LoRA weights into the base model before saving a dense HF checkpoint for vLLM."""
+    from peft import LoraConfig, get_peft_model
+
     adapter_cfg = os.path.join(local_dir, "lora_adapter", "adapter_config.json")
     if not os.path.isfile(adapter_cfg):
         return False

--- a/tests/test_model_merger.py
+++ b/tests/test_model_merger.py
@@ -1,0 +1,63 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import transformers.modeling_utils
+from transformers import AutoModelForCausalLM, GenerationConfig, GPT2Config
+
+from scripts.model_merger import save_pretrained_with_generation_config
+
+
+def test_save_pretrained_preserves_checkpoint_generation_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(transformers.modeling_utils, "unwrap_model", lambda model: model)
+    config = GPT2Config(
+        architectures=["GPT2LMHeadModel"],
+        bos_token_id=0,
+        eos_token_id=1,
+        n_embd=8,
+        n_head=1,
+        n_layer=1,
+        vocab_size=16,
+    )
+    config.save_pretrained(tmp_path)
+    GenerationConfig(eos_token_id=[1, 2], max_new_tokens=128, pad_token_id=1).save_pretrained(tmp_path)
+
+    original_generation_config = GenerationConfig.from_pretrained(tmp_path)
+    model = AutoModelForCausalLM.from_config(config)
+    assert model.generation_config.eos_token_id == 1
+
+    save_pretrained_with_generation_config(model, tmp_path, original_generation_config)
+
+    saved_generation_config = GenerationConfig.from_pretrained(tmp_path)
+    assert saved_generation_config.eos_token_id == [1, 2]
+    assert saved_generation_config.max_new_tokens == 128
+    assert saved_generation_config.pad_token_id == 1
+
+
+def test_save_pretrained_without_checkpoint_generation_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(transformers.modeling_utils, "unwrap_model", lambda model: model)
+    config = GPT2Config(
+        architectures=["GPT2LMHeadModel"],
+        bos_token_id=0,
+        eos_token_id=1,
+        n_embd=8,
+        n_head=1,
+        n_layer=1,
+        vocab_size=16,
+    )
+    model = AutoModelForCausalLM.from_config(config)
+
+    save_pretrained_with_generation_config(model, tmp_path, None)
+
+    saved_generation_config = GenerationConfig.from_pretrained(tmp_path)
+    assert saved_generation_config.eos_token_id == 1

--- a/tests/test_model_merger.py
+++ b/tests/test_model_merger.py
@@ -12,10 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
+from pathlib import Path
+
 import transformers.modeling_utils
 from transformers import AutoModelForCausalLM, GenerationConfig, GPT2Config
 
-from scripts.model_merger import save_pretrained_with_generation_config
+
+MODEL_MERGER_PATH = Path(__file__).parents[1] / "scripts" / "model_merger.py"
+MODEL_MERGER_SPEC = importlib.util.spec_from_file_location("model_merger", MODEL_MERGER_PATH)
+assert MODEL_MERGER_SPEC is not None and MODEL_MERGER_SPEC.loader is not None
+MODEL_MERGER = importlib.util.module_from_spec(MODEL_MERGER_SPEC)
+MODEL_MERGER_SPEC.loader.exec_module(MODEL_MERGER)
+save_pretrained_with_generation_config = MODEL_MERGER.save_pretrained_with_generation_config
 
 
 def test_save_pretrained_preserves_checkpoint_generation_config(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Preserve the checkpoint's `generation_config.json` when converting sharded EasyR1 checkpoints into merged Hugging Face models.

## Problem

`model_merger.py` reconstructs the output model only from `config.json` and then calls `save_pretrained()`. Transformers consequently derives a new generation config from the model config and overwrites the checkpoint-specific file.

This changes generation semantics when the two files intentionally differ. For example, a Qwen3 checkpoint can contain:

```text
config.json:            eos_token_id = 151643
generation_config.json: eos_token_id = [151643, 151645]
```

After merging, the current script writes only `151643`, so generation no longer stops on `<|im_end|>` (`151645`).

## Fix

- Load the checkpoint `GenerationConfig` before reconstructing the model.
- Attach it to the model before `save_pretrained()`.
- Apply the same behavior to dense and LoRA merge paths.
- Keep the previous behavior when no `generation_config.json` exists.

## Tests

Added `tests/test_model_merger.py` covering:

- preservation of multi-EOS and other generation fields;
- fallback behavior when the checkpoint has no generation config.

Validated with:

```text
pytest -q tests/test_model_merger.py  # 2 passed
ruff check scripts/model_merger.py tests/test_model_merger.py
ruff format --check scripts/model_merger.py tests/test_model_merger.py
python3.9 -m py_compile scripts/model_merger.py tests/test_model_merger.py
python3 tests/check_license.py scripts/model_merger.py tests/test_model_merger.py
```
